### PR TITLE
Update FBTSaver.cs

### DIFF
--- a/FBT Saver/FBTSaver.cs
+++ b/FBT Saver/FBTSaver.cs
@@ -7,6 +7,7 @@ using Harmony;
 using MelonLoader;
 using Newtonsoft.Json;
 using UnityEngine;
+using UIExpansionKit.API;
 
 namespace FBT_Saver
 {
@@ -73,6 +74,16 @@ namespace FBT_Saver
                         break;
                 }
             }
+
+            MelonLogger.Log("Adding UIX Button...");
+            ExpansionKitApi.RegisterSimpleMenuButton(ExpandedMenu.AvatarMenu, "Clear Saved FBT Calibrations", (() =>
+            {
+                _savedCalibrations.Clear();
+                File.Delete($"{CalibrationsDirectory}{CalibrationsFile}");
+                MelonLogger.Log("Cleared Saved Calibrations");
+            }
+            ));
+
             MelonLogger.Log("Done!");
         }
 


### PR DESCRIPTION
Added an option to clear saved Calibrations. While I do like the fact that the mod saves calibration offsets, sometimes it is easier to start over and having a button in game to do that instead of deleting the file manually and relaunching is more convenient. 